### PR TITLE
using head instead of vector subseting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: pesel
 Type: Package
 Title: Automatic Estimation of Number of Principal Components in PCA
-Version: 0.7.2
-Date: 2019-06-17
+Version: 0.7.3
+Date: 2021-04-25
 Author: Piotr Sobczyk, Julie Josse, Malgorzata Bogdan
 Maintainer: Piotr Sobczyk <pj.sobczyk@gmail.com>
 Description: Automatic estimation of number of principal components in PCA

--- a/R/auxilliary.R
+++ b/R/auxilliary.R
@@ -23,7 +23,7 @@ pesel_homogeneous <- function(X, minK, maxK){
     v <- sum(lambda[(k+1):d])/(d-k)
 
     t0 <- -N*d/2*log(2*pi)
-    t1 <- -N*k/2*log(mean(lambda[1:k]))
+    t1 <- -N*k/2*log(mean(head(lambda, k)))
     t2 <- -N*(d-k)/2*log(v)
     t3 <- -N*d/2
     pen <- -(m+d+1+1)/2*log(N)
@@ -57,7 +57,7 @@ pesel_heterogeneous <- function(X, minK, maxK){
     v <- sum(lambda[(k+1):d])/(d-k)
 
     t0 <- -N*d/2*log(2*pi)
-    t1 <- -N/2*sum(log(lambda[1:k]))
+    t1 <- -N/2*sum(log(head(lambda, k)))
     t2 <- -N*(d-k)/2*log(v)
     t3 <- -N*d/2
     pen <- -(m+d+k+1)/2*log(N)

--- a/R/pesel.R
+++ b/R/pesel.R
@@ -51,7 +51,6 @@ pesel <- function(X, npc.min = 1, npc.max = 10, prior = NULL, scale = TRUE,
   p = ncol(X)
   npc.max = min(npc.max, min(n,p)-1)
   npc.min = max(npc.min, 0)
-
   if(is.null(prior)){
     prior = rep(1/(npc.max - npc.min + 1), npc.max - npc.min + 1)
   } else if(length(prior) != npc.max - npc.min + 1){
@@ -64,14 +63,13 @@ pesel <- function(X, npc.min = 1, npc.max = 10, prior = NULL, scale = TRUE,
 
   method = match.arg(method)
 
-  if(class(X) == "data.frame"){
+  if("data.frame" %in% class(X)){
     X = as.matrix(X)
   }
 
   if(sum(sapply(X, is.numeric)) < p){
     stop("All the variables have to be numeric")
   }
-
   missing = which(is.na(X))
   if(length(missing) !=  0){
     stop("There are missing values")

--- a/R/pesel_package.R
+++ b/R/pesel_package.R
@@ -3,7 +3,7 @@
 #' @description Automatic estimation of number of principal components in PCA
 #' with PEnalized SEmi-integrated Likelihood (PESEL).
 #'
-#' @details Version: 0.7.2
+#' @details Version: 0.7.3
 #' @docType package
 #' @name pesel-package
 #' @importFrom stats cov


### PR DESCRIPTION
Fixing the mBIC computation for the case when the number of PCs is equal to 0